### PR TITLE
Add test-console for ubuntu 20.04

### DIFF
--- a/builder/Makefile.am
+++ b/builder/Makefile.am
@@ -397,7 +397,8 @@ console_test_scripts := \
 	test-console-ubuntu-12.04.sh \
 	test-console-ubuntu-14.04.sh \
 	test-console-ubuntu-16.04.sh \
-	test-console-ubuntu-18.04.sh
+	test-console-ubuntu-18.04.sh \
+	test-console-ubuntu-20.04.sh
 
 test-console-%.sh:
 	rm -f $@ $@-t


### PR DESCRIPTION
This seemed to be missing
