### PR TITLE
Add support for the yescrypt hash method.

### DIFF
--- a/bash/virt-alignment-scan
+++ b/bash/virt-alignment-scan
@@ -54,7 +54,7 @@ _guestfs_virttools ()
             COMPREPLY=( $( compgen -W "short long json" -- "$cur") )
             return ;;
         --password-crypto)
-            COMPREPLY=( $( compgen -W "md5 sha256 sha512" -- "$cur") )
+            COMPREPLY=( $( compgen -W "md5 sha256 sha512 yescrypt" -- "$cur") )
             return ;;
         --unknown-filesystems)
             COMPREPLY=( $( compgen -W "ignore warn error" -- "$cur") )

--- a/bash/virt-alignment-scan
+++ b/bash/virt-alignment-scan
@@ -1,5 +1,5 @@
 # virt-tools bash completion script -*- shell-script -*-
-# Copyright (C) 2010-2020 Red Hat Inc.
+# Copyright (C) 2010-2021 Red Hat Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/customize/password.ml
+++ b/customize/password.ml
@@ -1,5 +1,5 @@
 (* virt-sysprep
- * Copyright (C) 2012-2020 Red Hat Inc.
+ * Copyright (C) 2012-2021 Red Hat Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The yescrypt hashing method is considered to be much stronger than sha512crypt and fully supported by libxcrypt >= 4.3.

It is based on NIST-approved primitives, like PBKDF2, and on par with argon2 in strength.

Fresh installed systems, as well as newly computed hashes for the UNIX shadow file should prefer this method, if the crypt() function, the distro ships, is capable of computing such hashes.

***

See: https://fedoraproject.org/wiki/Changes/yescrypt_as_default_hashing_method_for_shadow