### PR TITLE
Ensure the machine-id operation is the last one

### DIFF
--- a/sysprep/sysprep_operation_machine_id.ml
+++ b/sysprep/sysprep_operation_machine_id.ml
@@ -32,6 +32,7 @@ let machine_id_perform (g : Guestfs.guestfs) root side_effects =
 
 let op = {
   defaults with
+    order = 999;
     name = "machine-id";
     enabled_by_default = true;
     heading = s_"Remove the local machine ID";


### PR DESCRIPTION
We must ensure the modified image doesn't have any content in
/etc/machine-id file. This will then trigger the usual
systemd-machine-id-setup during the first boot of the image, ensuring
we'll get an as unique as possible ID.

This is mandatory, since the tools are generating a machine-id at
different stages, for instance in order to ensure packages are
installing without any issue[1]

Of course, if the operator wants to get an actual machine-id, they can
just disable the "machine-id" operation. Note that it's enabled by
default, so the issue is more about ordering than anything.

[1] For instance here: https://github.com/rwmjones/guestfs-tools/blob/3a498512f58bc431db490e96cdb712b19389bda4/customize/customize_run.ml#L170-L188